### PR TITLE
Add logic to convert array to comma separated string

### DIFF
--- a/kong-plugin-jwt-claims-to-headers-1.0.0-1.rockspec
+++ b/kong-plugin-jwt-claims-to-headers-1.0.0-1.rockspec
@@ -1,6 +1,6 @@
 package = "kong-plugin-jwt-claims-to-headers"
 
-version = "1.0.0-1"               -- TODO: renumber, must match the info in the filename of this rockspec!
+version = "1.0.2-1"               -- TODO: renumber, must match the info in the filename of this rockspec!
 -- The version '0.1.0' is the source code version, the trailing '1' is the version of this rockspec.
 -- whenever the source version changes, the rockspec should be reset to 1. The rockspec version is only
 -- updated (incremented) when this file changes, but the source remains the same.

--- a/kong/plugins/jwt-claims-to-headers/handler.lua
+++ b/kong/plugins/jwt-claims-to-headers/handler.lua
@@ -130,6 +130,9 @@ function JwtClaimsToHeadersHandler:access(config)
         for key, value in pairs(claims_table) do
             local header = header_for_claim(key, config)
             if header ~= nil then
+                if type(value) == "table" then
+                    value = table.concat(value,",")
+                end
                 kong.log.debug("Set header: '", header, "' to value: '", value, "'")
                 kong.service.request.set_header(header, value)
             end

--- a/spec/jwt-claims-to-headers/jwt-claims-to-headers_spec.lua
+++ b/spec/jwt-claims-to-headers/jwt-claims-to-headers_spec.lua
@@ -8,12 +8,15 @@ local test_key = 'test_key'
 local test_secret = 'test_secret'
 local test_claim1_value = 'test_claim1_value'
 local test_claim2_value = 'test_claim2_value'
+local test_claim3_value = { 'test_claim3_value_1', 'test_claim3_value_2' }
+local expected_claim3_value = 'test_claim3_value_1,test_claim3_value_2'
 local iss_custom_header = "issCustomHeader"
 local claim1_custom_header = "claim1CustomHeader"
 local jwt_for_test = jwtParser.encode({
   iss = test_key,
   claim1 = test_claim1_value,
-  claim2 = test_claim2_value
+  claim2 = test_claim2_value,
+  claim3 = test_claim3_value
 }, test_secret, algo)
 local test_prefix = "X-MyPrefix-"
 local jwt_param_name = "custom_jwt"
@@ -45,7 +48,7 @@ end
 for _, strategy in helpers.each_strategy() do
   describe("Jwt-Claims-to-Headers-Plugin: (access) [#" .. strategy .. "]", function()
     local client
-    local bp = helpers.get_db_utils(strategy)
+    local bp = helpers.get_db_utils(strategy, nil, { "jwt-claims-to-headers" })
 
     setup(function()
 
@@ -135,11 +138,13 @@ for _, strategy in helpers.each_strategy() do
         local header_value_claim_iss = assert.request(r).has.header("X-Jwt-Claim-iss")
         local header_value_claim1 = assert.request(r).has.header("X-Jwt-Claim-claim1")
         local header_value_claim2 = assert.request(r).has.header("X-Jwt-Claim-claim2")
+        local header_value_claim3 = assert.request(r).has.header("X-Jwt-Claim-claim3")
 
         -- validate the value of the headers
         assert.equal(test_key, header_value_claim_iss)
         assert.equal(test_claim1_value, header_value_claim1)
         assert.equal(test_claim2_value, header_value_claim2)
+        assert.equal(expected_claim3_value, header_value_claim3)
       end)
 
 
@@ -158,10 +163,12 @@ for _, strategy in helpers.each_strategy() do
         local header_value_claim_iss = assert.request(r).has.header("X-Jwt-Claim-iss")
         local header_value_claim1 = assert.request(r).has.header("X-Jwt-Claim-claim1")
         local header_value_claim2 = assert.request(r).has.header("X-Jwt-Claim-claim2")
+        local header_value_claim3 = assert.request(r).has.header("X-Jwt-Claim-claim3")
         -- validate the value of the headers
         assert.equal(test_key, header_value_claim_iss)
         assert.equal(test_claim1_value, header_value_claim1)
         assert.equal(test_claim2_value, header_value_claim2)
+        assert.equal(expected_claim3_value, header_value_claim3)
       end)
     end)
 
@@ -222,11 +229,13 @@ for _, strategy in helpers.each_strategy() do
         local header_value_claim_iss = assert.request(r).has.header("X-Jwt-Claim-iss")
         local header_value_claim1 = assert.request(r).has.header("X-Jwt-Claim-claim1")
         local header_value_claim2 = assert.request(r).has.header("X-Jwt-Claim-claim2")
+        local header_value_claim3 = assert.request(r).has.header("X-Jwt-Claim-claim3")
 
         -- validate the value of the headers
         assert.equal(test_key, header_value_claim_iss)
         assert.equal(test_claim1_value, header_value_claim1)
         assert.equal(test_claim2_value, header_value_claim2)
+        assert.equal(expected_claim3_value, header_value_claim3)
       end)
 
     end)
@@ -248,10 +257,12 @@ for _, strategy in helpers.each_strategy() do
         local header_value_claim_iss = assert.request(r).has.header("X-Jwt-Claim-iss")
         local header_value_claim1 = assert.request(r).has.header("X-Jwt-Claim-claim1")
         local header_value_claim2 = assert.request(r).has.header("X-Jwt-Claim-claim2")
+        local header_value_claim3 = assert.request(r).has.header("X-Jwt-Claim-claim3")
         -- validate the value of that headers
         assert.equal(test_key, header_value_claim_iss)
         assert.equal(test_claim1_value, header_value_claim1)
         assert.equal(test_claim2_value, header_value_claim2)
+        assert.equal(expected_claim3_value, header_value_claim3)
       end)
 
       it("with a jwt as the Bearer token, contains the X-claims header", function()
@@ -269,11 +280,14 @@ for _, strategy in helpers.each_strategy() do
         local header_value_claim_iss = assert.request(r).has.header("X-Jwt-Claim-iss")
         local header_value_claim1 = assert.request(r).has.header("X-Jwt-Claim-claim1")
         local header_value_claim2 = assert.request(r).has.header("X-Jwt-Claim-claim2")
+        local header_value_claim3 = assert.request(r).has.header("X-Jwt-Claim-claim3")
         -- validate the value of that headers
         assert.equal(test_key, header_value_claim_iss)
         assert.equal(test_claim1_value, header_value_claim1)
         assert.equal(test_claim2_value, header_value_claim2)
+        assert.equal(expected_claim3_value, header_value_claim3)
       end)
+
     end)
 
     describe("unauthorized", function()


### PR DESCRIPTION
Auth0 is currently setting the gty claim as an array. This is causing failures since this plugin doesn't know how to handle an array. Adding the support. 

Error: 
`
2022/07/08 19:25:20 [error] 24#0: *212269 [kong] init.lua:271 [jwt-claims-to-headers] /opt/kong/plugins/jwt-claims-to-headers/handler.lua:134: invalid header value for "x-splash-gty": got table, expected string, number or boolean, client: 216.158.139.244, server: kong, request: "OPTIONS /me?access_token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlIySk5faEUteHJBa0Q1c05EVFlSUyJ9.eyJodHRwczovL2FwaS5zcGxhc2hyZWxlYXNlLmNvbS9zcGxhc2hfdXNlcl9pZCI6ODM0ODA5LCJodHRwczovL2FwaS5zcGxhc2hyZWxlYXNlLmNvbS9hcGlfY29uc3VtZXJfaWQiOiI4MzQ4MDkiLCJpc3MiOiJodHRwczovL2xvZ2luLnNwbGFzaHJlbGVhc2UuY29tLyIsInN1YiI6ImF1dGgwfHNwbGFzaC04MzQ4MDkiLCJhdWQiOiJodHRwczovL2FwaS5zcGxhc2hyZWxlYXNlLmNvbSIsImlhdCI6MTY1NzMwODA3NiwiZXhwIjoxNjU3MzA4OTc2LCJhenAiOiIyZ1pPejVjakx0a0doazRFaEx4Vjh6a3FvUzd4ZkRzcSIsInNjb3BlIjoidXNlciBvZmZsaW5lX2FjY2VzcyIsImd0eSI6WyJyZWZyZXNoX3Rva2VuIiwicGFzc3dvcmQiXX0.U7b-D64Qpomjts5wRvru8vo6PGRUMFYo4flOHrmX3DDW2PKj8hFXZKJmd9vc89hdHV2n6xPtI4rWlSEp8xztgl8yQ3wO_a0ai5jhD692f_58LE61xUEvp6_pH-RVneshhZuNGxrjCwbtWo6tk_G7mIZzBDE3OCGTybCRhX5uhRjAbylDywg5cFlGGJ-5MoJ6Xu3Cgpo7In_uYjp-M1VO0Z935taqSmUob4eNxsHlItr0wBu_yLwo0LPfIUTIGWUYQwvkDOlJANgOcBuizJiLZHPtzGAW9bPBzNVBMXFw6bfcmsKBMWinlxr29yzrpjNhfiTY8fE7ksc_fUQ6zHe-mg HTTP/1.1", host: "api.splashrelease.com", referrer: "https://app.splashrelease.com/"
`