### PR TITLE
[SWP-56782] Update the priority to have the plugin run before rate-li…

### DIFF
--- a/kong/plugins/jwt-claims-to-headers/handler.lua
+++ b/kong/plugins/jwt-claims-to-headers/handler.lua
@@ -4,7 +4,7 @@ local jwtParser = require "kong.plugins.jwt.jwt_parser"
 local JwtClaimsToHeadersHandler = BasePlugin:extend()
 
 -- ensure the priority is lower than the Jwt plugin, which has a priority of 1005
-JwtClaimsToHeadersHandler.PRIORITY = 10
+JwtClaimsToHeadersHandler.PRIORITY = 1200
 
 -- local functions ------------------------------
 


### PR DESCRIPTION
Ticket: https://splashthat.atlassian.net/browse/SWP-56782

This PR is to increase the priority of this plugin to be executed rate-limiting plugin since rate-limiting plugin has dependency on the headers generated by this plugin.

